### PR TITLE
Add basic volume control

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,5 +1,6 @@
 extern crate piston_window;
 extern crate music;
+extern crate sdl2_mixer;
 
 use piston_window::*;
 
@@ -16,7 +17,7 @@ fn main() {
 
     music::start::<Music, _>(|| {
         music::bind_file(Music::Piano, "./assets/piano.wav");
-        music::play(&Music::Piano, music::Repeat::Forever);
+        music::play(&Music::Piano, music::Repeat::Forever, sdl2_mixer::MAX_VOLUME);
         
         while let Some(e) = window.next() {
             window.draw_2d(&e, |_c, g| {

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -16,7 +16,8 @@ fn main() {
 
     music::start::<Music, _>(|| {
         music::bind_file(Music::Piano, "./assets/piano.wav");
-        music::play(&Music::Piano, music::Repeat::Forever, music::MAX_VOLUME);
+        music::set_volume(music::MAX_VOLUME);
+        music::play(&Music::Piano, music::Repeat::Forever);
         while let Some(e) = window.next() {
             window.draw_2d(&e, |_c, g| {
                 clear([1.0; 4], g);

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -18,6 +18,7 @@ fn main() {
         music::bind_file(Music::Piano, "./assets/piano.wav");
         music::set_volume(music::MAX_VOLUME);
         music::play(&Music::Piano, music::Repeat::Forever);
+
         while let Some(e) = window.next() {
             window.draw_2d(&e, |_c, g| {
                 clear([1.0; 4], g);

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,6 +1,5 @@
 extern crate piston_window;
 extern crate music;
-extern crate sdl2_mixer;
 
 use piston_window::*;
 
@@ -17,8 +16,7 @@ fn main() {
 
     music::start::<Music, _>(|| {
         music::bind_file(Music::Piano, "./assets/piano.wav");
-        music::play(&Music::Piano, music::Repeat::Forever, sdl2_mixer::MAX_VOLUME);
-        
+        music::play(&Music::Piano, music::Repeat::Forever, music::MAX_VOLUME);
         while let Some(e) = window.next() {
             window.draw_2d(&e, |_c, g| {
                 clear([1.0; 4], g);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,11 @@ impl Repeat {
 }
 
 /// Plays a music track.
-pub fn play<T: Eq + Hash + 'static + Any>(val: &T, repeat: Repeat) {
+///
+/// Set the volume on a scale of 0 to 128.
+/// Values greater than 128 will use 128.
+pub fn play<T: Eq + Hash + 'static + Any>(val: &T, repeat: Repeat, volume: isize) {
+    mix::Music::set_volume(volume);
     let _ = unsafe { current_music_tracks::<T>() }.get(val)
         .expect("music: Attempted to play value that is not bound to asset")
         .play(repeat.to_sdl2_repeats());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@ use std::hash::Hash;
 use std::any::Any;
 use std::path::Path;
 
+/// Minimum value for playback volume parameter.
+pub const MIN_VOLUME: f64 = 0.0;
+
 /// Maximum value for playback volume parameter.
 pub const MAX_VOLUME: f64 = 1.0;
 
@@ -88,14 +91,19 @@ impl Repeat {
     }
 }
 
-/// Plays a music track.
+/// Sets the volume of the music mixer.
 ///
 /// The volume is set on a scale of 0.0 to 1.0, which means 0-100%.
 /// Values greater than 1.0 will use 1.0.
 /// Values less than 0.0 will use 0.0.
-pub fn play<T: Eq + Hash + 'static + Any>(val: &T, repeat: Repeat, volume: f64) {
-    // Map 0.0 to 1.0 to 0 - 128 (sdl2_mixer::MAX_VOLUME).
-    mix::Music::set_volume((volume.max(0.0).min(1.0) * mix::MAX_VOLUME as f64) as isize);
+pub fn set_volume(volume: f64) {
+    // Map 0.0 - 1.0 to 0 - 128 (sdl2_mixer::MAX_VOLUME).
+    mix::Music::set_volume((volume.max(MIN_VOLUME).min(MAX_VOLUME) * mix::MAX_VOLUME as f64)
+        as isize);
+}
+
+/// Plays a music track.
+pub fn play<T: Eq + Hash + 'static + Any>(val: &T, repeat: Repeat) {
     let _ = unsafe { current_music_tracks::<T>() }.get(val)
         .expect("music: Attempted to play value that is not bound to asset")
         .play(repeat.to_sdl2_repeats());


### PR DESCRIPTION
Fixes #26 

@bvssvni please review and provide your feedback.  Disclaimer: I am very new to Rust.

In particular, should `music` provide a different (simpler?) API for volume?  Exposing the `sdl_mixer` 0-128 based volume seems to break the layering `music` tries to provide.  I'm not sure what alternative is better though. 

- Should we expose a 0.0-1.0 `f64` input that means 0-100%?
- 0-100 `i32` that means 0-100%?
- Should we use `u32` instead of `isize`?

Also, should volume be optional (and max if not provided)?  I know Rust doesn't have native default parameters, but I thought I read it was possible to emulate them in some way.