### PR TITLE
Use to latest SDL2 library in Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ rust:
 
 install:
   # Steps copied from the rust-sdl2 project.
-  - wget https://www.libsdl.org/release/SDL2-2.0.4.tar.gz -O sdl2.tar.gz
+  - wget https://www.libsdl.org/release/SDL2-2.0.5.tar.gz -O sdl2.tar.gz
   - tar xzf sdl2.tar.gz
-  - pushd SDL2-2.0.4 && ./configure && make && sudo make install && popd
+  - pushd SDL2-* && ./configure && make && sudo make install && popd
 
   # Steps copied from rust-sdl2_mixer project.
   - wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.1.tar.gz -O sdl2_mixer.tar.gz
   - tar xzf sdl2_mixer.tar.gz
-  - pushd SDL2_mixer-2.0.1 && ./configure && make && sudo make install && popd
+  - pushd SDL2_mixer-* && ./configure && make && sudo make install && popd
 
 matrix:
   allow_failures:


### PR DESCRIPTION
Use `*` to make the Travis build a little easier to maintain. Idea taken from [rust-sdl2](https://github.com/intellij-rust/intellij-rust/tree/fa8287accabcf19b610a6540144ffe6c6a1a8f6d/src/main/kotlin/org/rust/ide/spelling).