### PR TITLE
Fix path to SDL2 and SDL2_mixer libs in AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   global:
-    PROJECT_NAME: piston-music
+    PROJECT_NAME: music
 
   matrix:
       - TARGET: x86_64-pc-windows-msvc
@@ -24,12 +24,12 @@ install:
   # Install SDL2.
   - ps: Start-FileDownload https://www.libsdl.org/release/SDL2-devel-2.0.5-VC.zip -FileName sdl2.zip
   - ps: Expand-Archive sdl2.zip -DestinationPath sdl2
-  - set LIB=%LIB%;C:\projects\piston-music\sdl2\SDL2-2.0.5\lib\x64
+  - set LIB=%LIB%;C:\projects\music\sdl2\SDL2-2.0.5\lib\x64
 
   # Install SDL2_Mixer.
   - ps: Start-FileDownload https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.1-VC.zip -FileName sdl2_mixer.zip
   - ps: Expand-Archive sdl2_mixer.zip -DestinationPath sdl2_mixer
-  - set LIB=%LIB%;C:\projects\piston-music\sdl2_mixer\SDL2_mixer-2.0.1\lib\x64
+  - set LIB=%LIB%;C:\projects\music\sdl2_mixer\SDL2_mixer-2.0.1\lib\x64
   - ps: Get-ChildItem -Recurse -Depth 4
 
 # 'cargo test' takes care of building for us, so disable Appveyor's build stage. This prevents


### PR DESCRIPTION
Built successfully on my branch after this fix: https://ci.appveyor.com/project/johnthagen/music/build/1.0.2