### PR TITLE
Avoid multiple deference in match arms

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,9 +81,9 @@ pub enum Repeat {
 
 impl Repeat {
     fn to_sdl2_repeats(&self) -> i32 {
-        match self {
-            &Repeat::Forever => -1,
-            &Repeat::Times(val) => {
+        match *self {
+            Repeat::Forever => -1,
+            Repeat::Times(val) => {
                 val as i32
             }
         }


### PR DESCRIPTION
Found by running clippy: https://github.com/Manishearth/rust-clippy/wiki#match_ref_pats