### PR TITLE
Ignore intellij-rust project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ watch.sh
 !/examples/*.rs
 !/examples/assets/
 !/bin/assets/
+.idea
 
 Cargo.lock


### PR DESCRIPTION
This will ignore [`intellij-rust`](https://intellij-rust.github.io/) project files.