### PR TITLE
Remove mix alias and run rustfmt.

### DIFF
--- a/examples/test-mp3.rs
+++ b/examples/test-mp3.rs
@@ -15,10 +15,10 @@ fn main() {
         .unwrap();
 
     music::start::<Music, _>(|| {
-        music::bind_file(Music::Piano, "./assets/piano.mp3");
-        music::play(&Music::Piano, music::Repeat::Forever);
-        while let Some(e) = window.next() {
-            window.draw_2d(&e, |_c, g| { clear([1.0; 4], g); });
-        }
-    });
+                                 music::bind_file(Music::Piano, "./assets/piano.mp3");
+                                 music::play(&Music::Piano, music::Repeat::Forever);
+                                 while let Some(e) = window.next() {
+                                     window.draw_2d(&e, |_c, g| { clear([1.0; 4], g); });
+                                 }
+                             });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 extern crate current;
 extern crate sdl2;
 
-use sdl2::mixer as mix;
+use sdl2::mixer;
 use current::{Current, CurrentGuard};
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -21,17 +21,18 @@ pub const MAX_VOLUME: f64 = 1.0;
 fn init_audio() {
     // Load dynamic libraries.
     // Ignore formats that are not built in.
-    let _ = mix::init(mix::INIT_MP3 | mix::INIT_FLAC | mix::INIT_MOD | mix::INIT_FLUIDSYNTH |
-                      mix::INIT_MODPLUG | mix::INIT_OGG);
-    mix::open_audio(mix::DEFAULT_FREQUENCY,
-                    mix::DEFAULT_FORMAT,
-                    mix::DEFAULT_CHANNELS,
-                    1024)
-        .unwrap();
-    mix::allocate_channels(mix::DEFAULT_CHANNELS);
+    let _ = mixer::init(mixer::INIT_MP3 | mixer::INIT_FLAC | mixer::INIT_MOD |
+                        mixer::INIT_FLUIDSYNTH | mixer::INIT_MODPLUG |
+                        mixer::INIT_OGG);
+    mixer::open_audio(mixer::DEFAULT_FREQUENCY,
+                      mixer::DEFAULT_FORMAT,
+                      mixer::DEFAULT_CHANNELS,
+                      1024)
+            .unwrap();
+    mixer::allocate_channels(mixer::DEFAULT_CHANNELS);
 }
 
-unsafe fn current_music_tracks<T: 'static + Any>() -> Current<HashMap<T, mix::Music<'static>>> {
+unsafe fn current_music_tracks<T: 'static + Any>() -> Current<HashMap<T, mixer::Music<'static>>> {
     Current::new()
 }
 
@@ -42,7 +43,7 @@ pub fn start<T: Eq + Hash + 'static + Any, F: FnOnce()>(f: F) {
     let timer = sdl.timer().unwrap();
 
     init_audio();
-    let mut music_tracks: HashMap<T, mix::Music> = HashMap::new();
+    let mut music_tracks: HashMap<T, mixer::Music> = HashMap::new();
 
     let music_tracks_guard = CurrentGuard::new(&mut music_tracks);
 
@@ -59,7 +60,7 @@ pub fn bind_file<T, P>(val: T, file: P)
     where T: 'static + Eq + Hash + Any,
           P: AsRef<Path>
 {
-    let track = mix::Music::from_file(file.as_ref()).unwrap();
+    let track = mixer::Music::from_file(file.as_ref()).unwrap();
     unsafe { current_music_tracks() }.insert(val, track);
 }
 
@@ -88,8 +89,8 @@ impl Repeat {
 /// Values less than 0.0 will use 0.0.
 pub fn set_volume(volume: f64) {
     // Map 0.0 - 1.0 to 0 - 128 (sdl2_mixer::MAX_VOLUME).
-    mix::Music::set_volume((volume.max(MIN_VOLUME).min(MAX_VOLUME) * mix::MAX_VOLUME as f64) as
-                           i32);
+    mixer::Music::set_volume((volume.max(MIN_VOLUME).min(MAX_VOLUME) *
+                              mixer::MAX_VOLUME as f64) as i32);
 }
 
 /// Plays a music track.


### PR DESCRIPTION
I think now that we can import `mixer` directly from `sdl2` instead of having to import `sdl2_mixer`, the alias is as little less useful and having a more direct import could be better.

Latest `rustfmt` is also run.