### PR TITLE
SDL Context From Piston Window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ features = ["mixer"]
 
 [dev-dependencies]
 piston_window = "0.66.0"
+pistoncore-sdl2_window = "0.43.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "piston-music"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["bvssvni <bvssvni@gmail.com>"]
 keywords = ["piston", "music"]
 description = "A high level library for playing music"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,3 +42,4 @@ test_script:
   - cargo build --verbose
   - cargo build --verbose --example test
   - cargo build --example test-mp3
+  - cargo build --example test-sdl-context

--- a/examples/test-mp3.rs
+++ b/examples/test-mp3.rs
@@ -19,14 +19,14 @@ fn main() {
         .build()
         .unwrap();
 
-    music::start::<Music, Sound, _>(|| {
-                                    music::bind_music_file(Music::Piano, "./assets/piano.mp3");
-                                    music::bind_sound_file(Sound::Ding, "./assets/ding.mp3");
+    music::start::<Music, Sound, _>(None, || {
+        music::bind_music_file(Music::Piano, "./assets/piano.mp3");
+        music::bind_sound_file(Sound::Ding, "./assets/ding.mp3");
 
-                                    music::play_music(&Music::Piano, music::Repeat::Forever);
-                                    music::play_sound(&Sound::Ding, music::Repeat::Times(1));
-                                    while let Some(e) = window.next() {
-                                        window.draw_2d(&e, |_c, g| { clear([1.0; 4], g); });
-                                    }
-                                });
+        music::play_music(&Music::Piano, music::Repeat::Forever);
+        music::play_sound(&Sound::Ding, music::Repeat::Times(1));
+        while let Some(e) = window.next() {
+            window.draw_2d(&e, |_c, g| { clear([1.0; 4], g); });
+        }
+    });
 }

--- a/examples/test-mp3.rs
+++ b/examples/test-mp3.rs
@@ -19,7 +19,7 @@ fn main() {
         .build()
         .unwrap();
 
-    music::start::<Music, Sound, _>(None, || {
+    music::start::<Music, Sound, _>(|| {
         music::bind_music_file(Music::Piano, "./assets/piano.mp3");
         music::bind_sound_file(Sound::Ding, "./assets/ding.mp3");
 

--- a/examples/test-sdl-context.rs
+++ b/examples/test-sdl-context.rs
@@ -24,7 +24,7 @@ fn main() {
     // sdl context for audio
     let sdl = window.window.sdl_context.to_owned();
 
-    music::start::<Music, Sound, _>(Option::from(sdl), || {
+    music::start_with_context::<Music, Sound, _>(&sdl, || {
         music::bind_music_file(Music::Piano, "./assets/piano.wav");
         music::bind_sound_file(Sound::Ding, "./assets/ding.wav");
 

--- a/examples/test-sdl-context.rs
+++ b/examples/test-sdl-context.rs
@@ -1,7 +1,9 @@
 extern crate piston_window;
 extern crate music;
+extern crate sdl2_window;
 
 use piston_window::*;
+use sdl2_window::Sdl2Window;
 
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
 enum Music {
@@ -14,12 +16,15 @@ enum Sound {
 }
 
 fn main() {
-    let mut window: PistonWindow = WindowSettings::new("Test music", [640, 480])
+    let mut window: PistonWindow<Sdl2Window> = WindowSettings::new("Test music", [640, 480])
         .exit_on_esc(true)
         .build()
         .unwrap();
 
-    music::start::<Music, Sound, _>(None, || {
+    // sdl context for audio
+    let sdl = window.window.sdl_context.to_owned();
+
+    music::start::<Music, Sound, _>(Option::from(sdl), || {
         music::bind_music_file(Music::Piano, "./assets/piano.wav");
         music::bind_sound_file(Sound::Ding, "./assets/ding.wav");
 

--- a/examples/test-sdl-context.rs
+++ b/examples/test-sdl-context.rs
@@ -24,7 +24,7 @@ fn main() {
     // sdl context for audio
     let sdl = window.window.sdl_context.to_owned();
 
-    music::start_with_context::<Music, Sound, _>(&sdl, || {
+    music::start_context::<Music, Sound, _>(&sdl, || {
         music::bind_music_file(Music::Piano, "./assets/piano.wav");
         music::bind_sound_file(Sound::Ding, "./assets/ding.wav");
 

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -19,7 +19,7 @@ fn main() {
         .build()
         .unwrap();
 
-    music::start::<Music, Sound, _>(None, || {
+    music::start::<Music, Sound, _>(|| {
         music::bind_music_file(Music::Piano, "./assets/piano.wav");
         music::bind_sound_file(Sound::Ding, "./assets/ding.wav");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,12 @@ unsafe fn current_sound_tracks<T: 'static + Any>() -> Current<HashMap<T, mixer::
 
 /// Initializes audio and sets up current objects.
 pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>(context: Option<sdl2::Sdl>, f: F) {
-
+    let mut manage_sdl_context = true;
     let sdl = match context {
-       Some(sdl_context) => sdl_context,
+       Some(sdl_context) => {
+       			 manage_sdl_context = false;
+       			 sdl_context
+			 },
        None => sdl2::init().unwrap(),
     };
     
@@ -66,7 +69,9 @@ pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOn
     drop(music_tracks_guard);
     drop(timer);
     drop(audio);
-    drop(sdl);
+    if manage_sdl_context {
+       drop(sdl);
+    }
 }
 
 /// Binds a music file to value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,17 +42,17 @@ unsafe fn current_sound_tracks<T: 'static + Any>() -> Current<HashMap<T, mixer::
     Current::new()
 }
 
-/// Initializes audio and sets up current objects.
-pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>
-(context: Option<sdl2::Sdl>, f: F){
-    let mut manage_sdl_context = true;
-    let sdl = match context {
-        Some(sdl_context) => {
-            manage_sdl_context = false;
-            sdl_context
-        }
-        None => sdl2::init().unwrap(),
-    };
+/// Creates SDL context and starts the audio context
+pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>(f: F) {
+    let sdl = sdl2::init().unwrap();
+    start_with_context::<M, S, _>(&sdl, f);
+    drop(sdl);
+}
+
+/// Initializes audio and sets up current objects
+pub fn start_with_context<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>
+    (sdl: &sdl2::Sdl,
+     f: F) {
 
     let audio = sdl.audio().unwrap();
     let timer = sdl.timer().unwrap();
@@ -70,9 +70,6 @@ pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOn
     drop(music_tracks_guard);
     drop(timer);
     drop(audio);
-    if manage_sdl_context {
-        drop(sdl);
-    }
 }
 
 /// Binds a music file to value.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,11 +43,16 @@ unsafe fn current_sound_tracks<T: 'static + Any>() -> Current<HashMap<T, mixer::
 }
 
 /// Initializes audio and sets up current objects.
-pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>(f: F) {
-    let sdl = sdl2::init().unwrap();
+pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>(context: Option<sdl2::Sdl>, f: F) {
+
+    let sdl = match context {
+       Some(sdl_context) => sdl_context,
+       None => sdl2::init().unwrap(),
+    };
+    
     let audio = sdl.audio().unwrap();
     let timer = sdl.timer().unwrap();
-
+    
     init_audio();
     let mut music_tracks: HashMap<M, mixer::Music> = HashMap::new();
     let music_tracks_guard = CurrentGuard::new(&mut music_tracks);
@@ -56,7 +61,7 @@ pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOn
     let sound_tracks_guard = CurrentGuard::new(&mut sound_tracks);
 
     f();
-
+    
     drop(sound_tracks_guard);
     drop(music_tracks_guard);
     drop(timer);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,14 +45,14 @@ unsafe fn current_sound_tracks<T: 'static + Any>() -> Current<HashMap<T, mixer::
 /// Creates SDL context and starts the audio context
 pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>(f: F) {
     let sdl = sdl2::init().unwrap();
-    start_with_context::<M, S, _>(&sdl, f);
+    start_context::<M, S, _>(&sdl, f);
     drop(sdl);
 }
 
 /// Initializes audio and sets up current objects
-pub fn start_with_context<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>
+pub fn start_context<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>
     (sdl: &sdl2::Sdl,
-     f: F) {
+f: F){
 
     let audio = sdl.audio().unwrap();
     let timer = sdl.timer().unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,19 +43,20 @@ unsafe fn current_sound_tracks<T: 'static + Any>() -> Current<HashMap<T, mixer::
 }
 
 /// Initializes audio and sets up current objects.
-pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>(context: Option<sdl2::Sdl>, f: F) {
+pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOnce()>
+(context: Option<sdl2::Sdl>, f: F){
     let mut manage_sdl_context = true;
     let sdl = match context {
-       Some(sdl_context) => {
-       			 manage_sdl_context = false;
-       			 sdl_context
-			 },
-       None => sdl2::init().unwrap(),
+        Some(sdl_context) => {
+            manage_sdl_context = false;
+            sdl_context
+        }
+        None => sdl2::init().unwrap(),
     };
-    
+
     let audio = sdl.audio().unwrap();
     let timer = sdl.timer().unwrap();
-    
+
     init_audio();
     let mut music_tracks: HashMap<M, mixer::Music> = HashMap::new();
     let music_tracks_guard = CurrentGuard::new(&mut music_tracks);
@@ -64,13 +65,13 @@ pub fn start<M: Eq + Hash + 'static + Any, S: Eq + Hash + 'static + Any, F: FnOn
     let sound_tracks_guard = CurrentGuard::new(&mut sound_tracks);
 
     f();
-    
+
     drop(sound_tracks_guard);
     drop(music_tracks_guard);
     drop(timer);
     drop(audio);
     if manage_sdl_context {
-       drop(sdl);
+        drop(sdl);
     }
 }
 


### PR DESCRIPTION
Allow optional specification of the sdl context. Helps to avoid it being already initialized by another source such as the piston SDL window. 