### PR TITLE
Allow user to specify how many sound channels to allocate

### DIFF
--- a/examples/test-mp3.rs
+++ b/examples/test-mp3.rs
@@ -19,7 +19,7 @@ fn main() {
         .build()
         .unwrap();
 
-    music::start::<Music, Sound, _>(|| {
+    music::start::<Music, Sound, _>(16, || {
         music::bind_music_file(Music::Piano, "./assets/piano.mp3");
         music::bind_sound_file(Sound::Ding, "./assets/ding.mp3");
 

--- a/examples/test-sdl-context.rs
+++ b/examples/test-sdl-context.rs
@@ -24,7 +24,7 @@ fn main() {
     // sdl context for audio
     let sdl = window.window.sdl_context.to_owned();
 
-    music::start_context::<Music, Sound, _>(&sdl, || {
+    music::start_context::<Music, Sound, _>(&sdl, 16, || {
         music::bind_music_file(Music::Piano, "./assets/piano.wav");
         music::bind_sound_file(Sound::Ding, "./assets/ding.wav");
 

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -19,7 +19,7 @@ fn main() {
         .build()
         .unwrap();
 
-    music::start::<Music, Sound, _>(|| {
+    music::start::<Music, Sound, _>(16, || {
         music::bind_music_file(Music::Piano, "./assets/piano.wav");
         music::bind_sound_file(Sound::Ding, "./assets/ding.wav");
 


### PR DESCRIPTION
Without this, all applications using `piston_music` are limited to 16 sounds being played simultaneously. Better to allow the user to specify this.