### PR TITLE
Allow user to change sound volume independent of music volume

### DIFF
--- a/examples/test-mp3.rs
+++ b/examples/test-mp3.rs
@@ -23,8 +23,9 @@ fn main() {
         music::bind_music_file(Music::Piano, "./assets/piano.mp3");
         music::bind_sound_file(Sound::Ding, "./assets/ding.mp3");
 
+        music::set_volume(music::MAX_VOLUME);
         music::play_music(&Music::Piano, music::Repeat::Forever);
-        music::play_sound(&Sound::Ding, music::Repeat::Times(1));
+        music::play_sound(&Sound::Ding, music::Repeat::Times(1), music::MAX_VOLUME);
         while let Some(e) = window.next() {
             window.draw_2d(&e, |_c, g| { clear([1.0; 4], g); });
         }

--- a/examples/test-sdl-context.rs
+++ b/examples/test-sdl-context.rs
@@ -30,7 +30,7 @@ fn main() {
 
         music::set_volume(music::MAX_VOLUME);
         music::play_music(&Music::Piano, music::Repeat::Forever);
-        music::play_sound(&Sound::Ding, music::Repeat::Times(1));
+        music::play_sound(&Sound::Ding, music::Repeat::Times(1), music::MAX_VOLUME);
         while let Some(e) = window.next() {
             window.draw_2d(&e, |_c, g| { clear([1.0; 4], g); });
         }

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -25,7 +25,7 @@ fn main() {
 
         music::set_volume(music::MAX_VOLUME);
         music::play_music(&Music::Piano, music::Repeat::Forever);
-        music::play_sound(&Sound::Ding, music::Repeat::Times(1));
+        music::play_sound(&Sound::Ding, music::Repeat::Times(1), music::MAX_VOLUME);
         while let Some(e) = window.next() {
             window.draw_2d(&e, |_c, g| { clear([1.0; 4], g); });
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,15 +108,20 @@ impl Repeat {
     }
 }
 
-/// Sets the volume of the music mixer and all sound channels.
+/// Sets the volume of the music mixer.
 ///
 /// The volume is set on a scale of 0.0 to 1.0, which means 0-100%.
 /// Values greater than 1.0 will use 1.0.
 /// Values less than 0.0 will use 0.0.
 pub fn set_volume(volume: f64) {
-    // Map 0.0 - 1.0 to 0 - 128 (sdl2::mixer::MAX_VOLUME).
-    mixer::Music::set_volume((volume.max(MIN_VOLUME).min(MAX_VOLUME) *
-                              mixer::MAX_VOLUME as f64) as i32);
+    return mixer::Music::set_volume(to_sdl2_volume(volume));
+}
+
+/// Converts from piston_music volume representation to SDL2 representation.
+///
+/// Map 0.0 - 1.0 to 0 - 128 (sdl2::mixer::MAX_VOLUME).
+fn to_sdl2_volume(volume: f64) -> i32 {
+    (volume.max(MIN_VOLUME).min(MAX_VOLUME) * mixer::MAX_VOLUME as f64) as i32
 }
 
 /// Plays a music track.
@@ -128,10 +133,13 @@ pub fn play_music<T: Eq + Hash + 'static + Any>(val: &T, repeat: Repeat) {
 }
 
 /// Plays a sound effect track.
-pub fn play_sound<T: Eq + Hash + 'static + Any>(val: &T, repeat: Repeat) {
+///
+/// The volume is set on a scale of 0.0 to 1.0, which means 0-100%.
+/// Values greater than 1.0 will use 1.0.
+/// Values less than 0.0 will use 0.0.
+pub fn play_sound<T: Eq + Hash + 'static + Any>(val: &T, repeat: Repeat, volume: f64) {
     let channel = sdl2::mixer::Channel::all();
-    // Share the volume of the Music channel.
-    channel.set_volume(mixer::Music::get_volume());
+    channel.set_volume(to_sdl2_volume(volume));
     unsafe {
         channel
             .play(current_sound_tracks::<T>()


### PR DESCRIPTION
SDL2 doesn't have a notion of saving global sound effect volume. Before for simplicity, we simply used the music volume. But this will allow the user to store a volume for sound and pass it in when they play sounds and have full control over the volume that it's played at.