### PR TITLE
Bump CI to latest SDL2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,12 @@ rust:
 
 install:
   # Steps copied from the rust-sdl2 project.
-  - wget https://www.libsdl.org/release/SDL2-2.0.8.tar.gz -O sdl2.tar.gz
+  - wget https://www.libsdl.org/release/SDL2-2.0.10.tar.gz -O sdl2.tar.gz
   - tar xzf sdl2.tar.gz
   - pushd SDL2-* && ./configure && make && sudo make install && popd
 
   # Steps copied from rust-sdl2_mixer project.
-  - wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.2.tar.gz -O sdl2_mixer.tar.gz
+  - wget https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.0.4.tar.gz -O sdl2_mixer.tar.gz
   - tar xzf sdl2_mixer.tar.gz
   - pushd SDL2_mixer-* && ./configure && make && sudo make install && popd
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # music
 [![Build Status](https://travis-ci.org/PistonDevelopers/music.svg)](https://travis-ci.org/PistonDevelopers/music)
-[![Build status](https://ci.appveyor.com/api/projects/status/axt1564g44543ofi?svg=true)](https://ci.appveyor.com/project/bvssvni/music-l080n)
+[![Build status](https://ci.appveyor.com/api/projects/status/axt1564g44543ofi/branch/master?svg=true)](https://ci.appveyor.com/project/bvssvni/music-l080n)
 [![Crates.io](https://img.shields.io/crates/v/piston-music.svg)](https://crates.io/crates/piston-music)
 [![Crates.io](https://img.shields.io/crates/d/piston-music.svg)](https://crates.io/crates/piston-music)
 [![Crates.io](https://img.shields.io/crates/l/piston-music.svg)](https://github.com/PistonDevelopers/music/blob/master/LICENSE-MIT)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,14 +22,14 @@ install:
   - cargo -V
 
   # Install SDL2.
-  - ps: Start-FileDownload https://www.libsdl.org/release/SDL2-devel-2.0.8-VC.zip -FileName sdl2.zip
+  - ps: Start-FileDownload https://www.libsdl.org/release/SDL2-devel-2.0.10-VC.zip -FileName sdl2.zip
   - ps: Expand-Archive sdl2.zip -DestinationPath sdl2
-  - set LIB=%LIB%;C:\projects\music\sdl2\SDL2-2.0.8\lib\x64
+  - set LIB=%LIB%;C:\projects\music\sdl2\SDL2-2.0.10\lib\x64
 
   # Install SDL2_Mixer.
-  - ps: Start-FileDownload https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.2-VC.zip -FileName sdl2_mixer.zip
+  - ps: Start-FileDownload https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-VC.zip -FileName sdl2_mixer.zip
   - ps: Expand-Archive sdl2_mixer.zip -DestinationPath sdl2_mixer
-  - set LIB=%LIB%;C:\projects\music\sdl2_mixer\SDL2_mixer-2.0.2\lib\x64
+  - set LIB=%LIB%;C:\projects\music\sdl2_mixer\SDL2_mixer-2.0.4\lib\x64
   - ps: Get-ChildItem -Recurse -Depth 4
 
 # 'cargo test' takes care of building for us, so disable Appveyor's build stage. This prevents

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,12 +24,12 @@ install:
   # Install SDL2.
   - ps: Start-FileDownload https://www.libsdl.org/release/SDL2-devel-2.0.10-VC.zip -FileName sdl2.zip
   - ps: Expand-Archive sdl2.zip -DestinationPath sdl2
-  - set LIB=%LIB%;C:\projects\music\sdl2\SDL2-2.0.10\lib\x64
+  - set LIB=%LIB%;C:\projects\music-l080n\sdl2\SDL2-2.0.10\lib\x64
 
   # Install SDL2_Mixer.
   - ps: Start-FileDownload https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.4-VC.zip -FileName sdl2_mixer.zip
   - ps: Expand-Archive sdl2_mixer.zip -DestinationPath sdl2_mixer
-  - set LIB=%LIB%;C:\projects\music\sdl2_mixer\SDL2_mixer-2.0.4\lib\x64
+  - set LIB=%LIB%;C:\projects\music-l080n\sdl2_mixer\SDL2_mixer-2.0.4\lib\x64
   - ps: Get-ChildItem -Recurse -Depth 4
 
 # 'cargo test' takes care of building for us, so disable Appveyor's build stage. This prevents


### PR DESCRIPTION
- Update CI to use the latest SDL2.
- Fix Windows CI.
- Update Appveyor badge to point to the latest master build rather than the latest build for any branch.